### PR TITLE
Refactor dependencies to use `iced` only instead of `iced_widget` and `iced_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ members = [".", "examples/split-chart"]
 [dependencies]
 plotters = { version = "0.3", default-features = false }
 plotters-backend = "0.3"
-iced_widget = { version = "0.13", features = ["canvas"] }
-iced_graphics = "0.13"
+iced = { version = "0.13", features = ["canvas", "tokio", "advanced"] }
 once_cell = "1"
 
 [dev-dependencies]
@@ -30,7 +29,6 @@ plotters = { version = "0.3", default-features = false, features = [
     "line_series",
     "point_series",
 ] }
-iced = { version = "0.13", features = ["canvas", "tokio"] }
 chrono = { version = "0.4", default-features = false }
 rand = "0.8"
 tokio = { version = "1", features = ["rt"], default-features = false }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -6,15 +6,12 @@
 
 use std::collections::HashSet;
 
-use iced_graphics::core::text::Paragraph;
-use iced_widget::{
-    canvas,
-    core::{
-        alignment::{Horizontal, Vertical},
-        font, text, Font, Size,
-    },
-    text::Shaping,
-};
+use iced::advanced::text;
+use iced::advanced::text::Paragraph;
+use iced::alignment::{Horizontal, Vertical};
+use iced::widget::canvas;
+use iced::widget::text::Shaping;
+use iced::{font, Font, Size};
 use once_cell::unsync::Lazy;
 use plotters_backend::{
     text_anchor,
@@ -275,7 +272,7 @@ where
             text_anchor::VPos::Bottom => Vertical::Bottom,
         };
 
-        let p = B::Paragraph::with_text(iced_widget::core::text::Text {
+        let p = B::Paragraph::with_text(text::Text {
             content: text,
             bounds,
             size: self.backend.default_size(),
@@ -284,7 +281,7 @@ where
             horizontal_alignment,
             vertical_alignment,
             shaping: self.shaping,
-            wrapping: iced_widget::core::text::Wrapping::Word,
+            wrapping: text::Wrapping::Word,
         });
         let size = p.min_bounds();
         Ok((size.width as u32, size.height as u32))

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -4,14 +4,10 @@
 // Copyright: 2022, Joylei <leingliu@gmail.com>
 // License: MIT
 
-use iced_widget::canvas::Cache;
-use iced_widget::core::event::Status;
-use iced_widget::core::mouse::Interaction;
-use iced_widget::core::Rectangle;
-use iced_widget::{
-    canvas::{Event, Frame, Geometry},
-    core::{mouse::Cursor, Size},
-};
+use iced::event::Status;
+use iced::mouse::{Cursor, Interaction};
+use iced::widget::canvas::{Cache, Event, Frame, Geometry};
+use iced::{Rectangle, Size};
 use plotters::{chart::ChartBuilder, coord::Shift, drawing::DrawingArea};
 use plotters_backend::DrawingBackend;
 
@@ -120,9 +116,9 @@ pub trait Chart<Message> {
         self.build_chart(state, builder);
     }
 
-    /// draw on [`iced_widget::canvas::Canvas`]
+    /// draw on [`iced::widget::canvas::Canvas`]
     ///
-    /// override this method if you want to use [`iced_widget::canvas::Cache`]
+    /// override this method if you want to use [`iced::widget::canvas::Cache`]
     ///
     /// ## Example
     /// ```rust,ignore

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,20 +4,19 @@
 // Copyright: 2022, Joylei <leingliu@gmail.com>
 // License: MIT
 
-use iced_widget::{
+use iced::advanced::{graphics::geometry, renderer, text, Layout};
+use iced::widget::{
     canvas::{Cache, Frame, Geometry},
-    core::{Layout, Size, Vector},
     text::Shaping,
 };
+use iced::{Size, Vector};
 use plotters::prelude::DrawingArea;
 
 use crate::backend::IcedChartBackend;
 use crate::Chart;
 
 /// Graphics Renderer
-pub trait Renderer:
-    iced_widget::core::Renderer + iced_widget::core::text::Renderer + iced_graphics::geometry::Renderer
-{
+pub trait Renderer: renderer::Renderer + text::Renderer + geometry::Renderer {
     /// draw a [Chart]
     fn draw_chart<Message, C>(
         &mut self,
@@ -29,7 +28,7 @@ pub trait Renderer:
         C: Chart<Message>;
 }
 
-impl crate::chart::Renderer for iced_widget::renderer::Renderer {
+impl crate::chart::Renderer for iced::Renderer {
     fn draw<F: Fn(&mut Frame)>(&self, size: Size, f: F) -> Geometry {
         let mut frame = Frame::new(self, size);
         f(&mut frame);
@@ -41,7 +40,7 @@ impl crate::chart::Renderer for iced_widget::renderer::Renderer {
     }
 }
 
-impl Renderer for iced_widget::renderer::Renderer {
+impl Renderer for iced::Renderer {
     fn draw_chart<Message, C>(
         &mut self,
         state: &C::State,
@@ -61,8 +60,8 @@ impl Renderer for iced_widget::renderer::Renderer {
             chart.draw_chart(state, root);
         });
         let translation = Vector::new(bounds.x, bounds.y);
-        iced_widget::core::Renderer::with_translation(self, translation, |renderer| {
-            iced_graphics::geometry::Renderer::draw_geometry(renderer, geometry);
+        renderer::Renderer::with_translation(self, translation, |renderer| {
+            geometry::Renderer::draw_geometry(renderer, geometry);
         });
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,8 @@
 // Copyright: 2022, Joylei <leingliu@gmail.com>
 // License: MIT
 
-use iced_widget::canvas;
-use iced_widget::core::{Color, Point};
+use iced::widget::canvas;
+use iced::{Color, Point};
 use plotters_backend::{BackendColor, BackendCoord, BackendStyle};
 
 pub(crate) trait AndExt {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,22 +8,6 @@ use iced::widget::canvas;
 use iced::{Color, Point};
 use plotters_backend::{BackendColor, BackendCoord, BackendStyle};
 
-pub(crate) trait AndExt {
-    fn and<F: Fn(Self) -> Self>(self, f: F) -> Self
-    where
-        Self: Sized;
-}
-
-impl<T> AndExt for T {
-    #[inline(always)]
-    fn and<F: Fn(Self) -> Self>(self, f: F) -> Self
-    where
-        Self: Sized,
-    {
-        f(self)
-    }
-}
-
 #[inline]
 pub(crate) fn cvt_color(color: &BackendColor) -> Color {
     let ((r, g, b), a) = (color.rgb, color.alpha);

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -4,19 +4,13 @@
 // Copyright: 2022, Joylei <leingliu@gmail.com>
 // License: MIT
 
-use core::marker::PhantomData;
+use std::marker::PhantomData;
 
-use iced_widget::{
-    canvas::Event,
-    core::{
-        event,
-        mouse::Cursor,
-        renderer::Style,
-        widget::{tree, Tree},
-        Element, Layout, Length, Rectangle, Shell, Size, Widget,
-    },
-    text::Shaping,
-};
+use iced::advanced::widget::{tree, Tree};
+use iced::advanced::{layout, mouse, renderer, Clipboard, Layout, Shell, Widget};
+use iced::widget::canvas;
+use iced::widget::text::Shaping;
+use iced::{mouse::Cursor, Element, Length, Rectangle, Size};
 
 use crate::renderer::Renderer;
 
@@ -92,10 +86,10 @@ where
         &self,
         _tree: &mut Tree,
         _renderer: &Renderer,
-        limits: &iced_widget::core::layout::Limits,
-    ) -> iced_widget::core::layout::Node {
+        limits: &layout::Limits,
+    ) -> layout::Node {
         let size = limits.resolve(self.width, self.height, Size::ZERO);
-        iced_widget::core::layout::Node::new(size)
+        layout::Node::new(size)
     }
 
     #[inline]
@@ -104,9 +98,9 @@ where
         tree: &Tree,
         renderer: &mut Renderer,
         _theme: &Theme,
-        _style: &Style,
+        _defaults: &renderer::Style,
         layout: Layout<'_>,
-        _cursor_position: Cursor,
+        _cursor: Cursor,
         _viewport: &Rectangle,
     ) {
         let state = tree.state.downcast_ref::<C::State>();
@@ -117,20 +111,18 @@ where
     fn on_event(
         &mut self,
         tree: &mut Tree,
-        event: iced_widget::core::Event,
+        event: iced::Event,
         layout: Layout<'_>,
         cursor: Cursor,
         _renderer: &Renderer,
-        _clipboard: &mut dyn iced_widget::core::Clipboard,
+        _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         _rectangle: &Rectangle,
-    ) -> event::Status {
+    ) -> iced::event::Status {
         let bounds = layout.bounds();
         let canvas_event = match event {
-            iced_widget::core::Event::Mouse(mouse_event) => Some(Event::Mouse(mouse_event)),
-            iced_widget::core::Event::Keyboard(keyboard_event) => {
-                Some(Event::Keyboard(keyboard_event))
-            }
+            iced::Event::Mouse(mouse_event) => Some(canvas::Event::Mouse(mouse_event)),
+            iced::Event::Keyboard(keyboard_event) => Some(canvas::Event::Keyboard(keyboard_event)),
             _ => None,
         };
         if let Some(canvas_event) = canvas_event {
@@ -143,7 +135,7 @@ where
             }
             return event_status;
         }
-        event::Status::Ignored
+        iced::event::Status::Ignored
     }
 
     fn mouse_interaction(
@@ -153,7 +145,7 @@ where
         cursor: Cursor,
         _viewport: &Rectangle,
         _renderer: &Renderer,
-    ) -> iced_widget::core::mouse::Interaction {
+    ) -> mouse::Interaction {
         let state = tree.state.downcast_ref::<C::State>();
         let bounds = layout.bounds();
         self.chart.mouse_interaction(state, bounds, cursor)


### PR DESCRIPTION
This makes it easier for users to pin to match with their `iced` dependency.